### PR TITLE
Update import path

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -3,7 +3,7 @@ package gormrus
 import (
 	"database/sql/driver"
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"


### PR DESCRIPTION
Since go 1.11 with go modules, I'm getting this error:

```
go: github.com/Sirupsen/logrus@v1.2.0: parsing go.mod: unexpected module path "github.com/sirupsen/logrus"
go: error loading module requirements
```

Looks because of the go modules mechanism is case sensitive. Actual repo name is `github.com/sirupsen/logrus` and it doesn't recognize `github.com/Sirupsen/logrus`.

Validated this change (on my fork repo) it works fine 👍 